### PR TITLE
Selenium quick tour introduction

### DIFF
--- a/ide.html
+++ b/ide.html
@@ -1,0 +1,9 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>Selenium IDE</title>
+<link rel=stylesheet href=se.css>
+<link rel=prev href=start.html title="Getting Started">
+<link rel=next href=remote.html title="Remote WebDriver">
+<script src=docs.js></script>
+
+<h1>Selenium IDE</h1>

--- a/index.html
+++ b/index.html
@@ -58,8 +58,11 @@ search_box.submit()</code></pre>
 <div id=gettingstarted><ul>
  <li><a href=quick.html#quick_tour>Quick Tour</a>
   <ul>
-   <li><a href=quick.html#first>First</a>
-   <li><a href=quick.html#second>Second</a>
+   <li><a href=quick.html#webdriver>WebDriver</a>
+   <li><a href=quick.html#selenium_remote_control>Selenium Remote
+   Control</a>
+   <li><a href=quick.html#selenium_ide>Selenium IDE</a>
+   <li><a href=quick.html#selenium_grid>Selenium Grid</a>
   </ul></li>
 </ul>
 </div>

--- a/quick.html
+++ b/quick.html
@@ -7,7 +7,49 @@
 <script src=docs.js></script>
 
 <h1>Quick Tour</h1>
+Selenium is not just one tool or API but it composes many tools -
 
-<h2>First</h2>
+<h2>WebDriver</h2>
 
-<h2>Second</h2>
+<p><em><a href=wd.html>WebDriver</a></em>, is also known as Selenium
+2. If you are beginning with desktop website test automation then you
+are going to be using WebDriver APIs. WebDriver uses browser
+automation APIs provided by browser vendors to control browser and
+run tests. This is as if real user is operating the browser. Since
+WebDriver does not require its API to be compiled with application
+code hence it is not intrusive in nature. Hence you are testing he
+same application which you push live.
+
+<h2>Selenium Remote Control</h2>
+
+<p><em><a href=rc.html>Selenium Remote Control</a></em>, is also known
+as Selenium 1. Selenium RC was the most prominent Selenium tool
+before the advent of Selenium WebDriver. Selenium RC would use a
+proxy server and inject java script in browser to be able to control
+it. Given the intrusive nature Selenium RC had on browser,
+you were never sure if you are pushing the same application live what
+you tested. Selenium 2 APIs yet contain Selenium RC APIs but
+Selenium 3 would completely get rid of Selenium RC APIs. If you are
+still using Selenium RC then you must
+<em><a href=rctowd.html>migrate</a></em> to Selenium WebDriver.
+
+<h2>Selenium IDE</h2>
+
+<p><em><a href=ide.html>Selenium IDE</a></em>, is a
+firefox plugin which can be used to record test steps on a firefox
+browser. Selenium IDE can be used to generate <i>quick and dirty</i>
+ test code and convert in a variety of programming languages (i.e. c#,
+java, python and ruby). Given the maintainability of code generated
+through Selenium IDE, it is not recommended to use it for any thing
+more than getting acquainted with element locators or generating
+<i>throw away code</i>. We are sure that once you get used to
+WebDriver API then you will never use Selenium IDE.
+
+
+<h2>Selenium Grid</h2>
+
+<p> Soon after development of WebDriver tests you may face need of
+running your test on multiple combinations of browser/operating
+system. This is where <em><a href=grid.html>Selenium Grid</a></em>
+comes to rescue.
+

--- a/rc.html
+++ b/rc.html
@@ -1,0 +1,9 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>Selenium Remote Control</title>
+<link rel=stylesheet href=se.css>
+<link rel=prev href=start.html title="Getting Started">
+<link rel=next href=remote.html title="Remote WebDriver">
+<script src=docs.js></script>
+
+<h1>Selenium Remote Control</h1>

--- a/rctowd.html
+++ b/rctowd.html
@@ -1,0 +1,9 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>Selenium Remote Control to WebDriver migration</title>
+<link rel=stylesheet href=se.css>
+<link rel=prev href=start.html title="Getting Started">
+<link rel=next href=remote.html title="Remote WebDriver">
+<script src=docs.js></script>
+
+<h1>Selenium Remote Control to WebDriver migration</h1>


### PR DESCRIPTION
I had a first stab at it. quick.html is an intro of selenium set of tools. 
I suppose for more specific language and browser example for WebDriver, wd.html (or sub pages of it) would be right place.

Issue Number: https://github.com/SeleniumHQ/docs/issues/69
