### PR TITLE
Add release year for Selenium 1 on Introduction

### DIFF
--- a/intro.html
+++ b/intro.html
@@ -101,7 +101,7 @@
 
 <h3>History</h3>
 
-<p>When Selenium 1 released over N years ago
+<p>When Selenium 1 was released in 2004
  it was out of the necessity to reduce time spent
  manually verifying consistent behaviour in the front-end of a web application.
  It made use of what tools were available at the time,


### PR DESCRIPTION
Removed the phrase 'Selenium released N years ago' to the year it was released.
2nd point on issue #121 