### PR TITLE
Update id for Google search box

### DIFF
--- a/index.html
+++ b/index.html
@@ -39,7 +39,7 @@
 
 driver = webdriver.Firefox()
 driver.get("http://google.com/?hl=en")
-search_box = driver.find_element_by_id("q")
+search_box = driver.find_element_by_id("lst-ib")
 search_box.send_keys("cheese")
 search_box.submit()</code></pre>
 


### PR DESCRIPTION
The initial id for Google search box, "q" didn't work and gave the error 'Element not found'. So updated it to "lst-ib", which works.