### PR TITLE
Add intro snippets for Java and JavaScript

### DIFF
--- a/index.html
+++ b/index.html
@@ -35,13 +35,56 @@
  Here is one of the simplest instructions you can make:
 
 <!-- TODO(ato): We should find a better example.  Perhaps Todo list? -->
-<pre><code class=python>from selenium import webdriver
+<pre>
+ <code class=java>import org.openqa.selenium.By;
+import org.openqa.selenium.Keys;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.firefox.FirefoxDriver;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+
+public class HelloSelenium {
+
+    public static void main(String[] args) {
+        WebDriver driver = new FirefoxDriver();
+        driver.manage().timeouts().implicitlyWait(10, SECONDS);
+        try {
+            driver.get("http://google.com/ncr");
+            driver.findElement(By.name("q")).sendKeys("cheese" + Keys.RETURN);
+            WebElement firstResult = driver.findElement(By.cssSelector("h3>a"));
+            System.out.println(firstResult.getText());
+        } finally {
+            driver.quit();
+        }
+    }
+}</code>
+ <code class=python>from selenium import webdriver
+from selenium.webdriver.common.keys import Keys
 
 driver = webdriver.Firefox()
-driver.get("http://google.com/?hl=en")
-search_box = driver.find_element_by_name("q")
-search_box.send_keys("cheese")
-search_box.submit()</code></pre>
+driver.implicitly_wait(10)
+try:
+    driver.get("http://google.com/ncr")
+    driver.find_element_by_name("q").send_keys("cheese" + Keys.RETURN)
+    first_result = driver.find_element_by_css_selector("h3>a")
+    print(first_result.text)
+finally:
+    driver.quit()</code>
+ <code class=javascript>const {Builder, By, Key, until} = require('selenium-webdriver');
+
+(async function example() {
+    let driver = await new Builder().forBrowser('firefox').build();
+    driver.manage().setTimeouts({implicit:10000});
+    try {
+        await driver.get('http://www.google.com/ncr');
+        await driver.findElement(By.name('q')).sendKeys('cheese', Key.RETURN);
+        let firstResult = await driver.findElement(By.css('h3>a'));
+        console.log(await firstResult.getText());
+    } finally {
+        await driver.quit();
+    }
+})();</code></pre>
 
 <p>See the <em><a href=quick.html>Quick Tour</a></em>
  for a full explanation

--- a/se.css
+++ b/se.css
@@ -146,6 +146,7 @@ pre code { font-size: 100% }
  position: relative;
  top: -10px;
  background-color: white;
+ cursor: pointer;
 }
 .languageSelect>span.chosen{
  padding: 8px;


### PR DESCRIPTION
Added sample scripts for java and javascript on the front page.  The examples should perform exactly the same steps for all three examples.

Switched to using implicit wait because it works well for the example/beginners and using try/catch to ensure the browser clears up after itself (without `quit()` we leave zombie driver processes running, which can be confusing for beginners).

Decided to use use try/catch instead of third party libraries like JUnit.  Let me know your thoughts on this, as typically we wouldn't expect users to write a main class in java to run test code, but I liked the idea of something only using built in components that you could copy from your browser straight into an IDE.

## Java
![image](https://user-images.githubusercontent.com/11080542/42725350-08a80ee6-877a-11e8-9e09-00b98ac5c340.png)


## Python (modified)
![image](https://user-images.githubusercontent.com/11080542/42725375-5b4a0398-877a-11e8-9217-394fd289466c.png)


## Javascript
![image](https://user-images.githubusercontent.com/11080542/42725362-3a5ffea8-877a-11e8-91e5-a89241e5ced6.png)
