### PR TITLE
Fix maxSession directive in nodeConfig example

### DIFF
--- a/grid.html
+++ b/grid.html
@@ -159,7 +159,7 @@
 
 <pre><code class=json>{"_comment" : "Configuration for Hub - hubConfig.json",
   "host": ip,
-  "maxSessions": 5,
+  "maxSession": 5,
   "port": 4444,
   "cleanupCycle": 5000,
   "timeout": 300000,
@@ -224,7 +224,7 @@
       "platform": "WINDOWS",
       "maxInstances": 5,
       "firefox_binary": "",
-      "cleanSession": true 
+      "cleanSession": true
     },
     {
       "browserName": "chrome",
@@ -236,7 +236,7 @@
       "browserName": "internet explorer",
       "maxInstances": 1,
       "platform": "WINDOWS",
-      "webdriver.ie.driver": "C:/Program Files (x86)/Internet Explorer/iexplore.exe" 
+      "webdriver.ie.driver": "C:/Program Files (x86)/Internet Explorer/iexplore.exe"
     }
   ],
   "configuration": {
@@ -248,6 +248,6 @@
     "host": ip,
     "register": true,
     "hubPort": 4444,
-    "maxSessions": 5
+    "maxSession": 5
   }
 }</code></pre>


### PR DESCRIPTION
There seems to be a typo. The directive is actually maxSession: https://github.com/SeleniumHQ/selenium/blob/4c39e9d0894068dcdb29094217510b2fed892143/java/server/src/org/openqa/grid/common/defaults/DefaultNodeWebDriver.json#L30 etc.

Using `maxSessions` does not affect the actual node configuration at all.