### PR TITLE
Refresh CSharp example for index

### DIFF
--- a/index.html
+++ b/index.html
@@ -86,7 +86,7 @@ class HelloSelenium
         using (IWebDriver driver = new FirefoxDriver())
         {
             WebDriverWait wait = new WebDriverWait(driver, TimeSpan.FromSeconds(10));
-            driver.Navigate().GoToUrl("http://www.google.com/");
+            driver.Navigate().GoToUrl("https://www.google.com/ncr");
             driver.FindElement(By.Name("q")).SendKeys("cheese" + Keys.Enter);
             IWebElement firstResult = wait.Until(ExpectedConditions.ElementExists(By.CssSelector("h3>a")));
             Console.WriteLine(firstResult.Text);

--- a/index.html
+++ b/index.html
@@ -74,33 +74,22 @@ with webdriver.Firefox() as driver:
     first_result = wait.until(presence_of_element_located((By.CSS_SELECTOR, "h3>a")))
     print(first_result.text)</code>
  <code class=cs>using System;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 using OpenQA.Selenium;
 using OpenQA.Selenium.Firefox;
 using OpenQA.Selenium.Support.UI;
+using SeleniumExtras.WaitHelpers;
 
-namespace Selenium.Docs
+class HelloSelenium
 {
-    [TestClass]
-    public class HelloSelenium
+    static void Main()
     {
-        private static IWebDriver driver;
-
-        [TestMethod]
-        public void Example()
+        using (IWebDriver driver = new FirefoxDriver())
         {
-            driver = new FirefoxDriver();
             WebDriverWait wait = new WebDriverWait(driver, TimeSpan.FromSeconds(10));
-            driver.Navigate().GoToUrl("http://www.google.com/ncr");
-            driver.FindElement(By.Name("q")).SendKeys("cheese" + Keys.Return);
-            IWebElement firstResult = wait.Until(wd => wd.FindElement(By.CssSelector("h3>a")));
+            driver.Navigate().GoToUrl("http://www.google.com/");
+            driver.FindElement(By.Name("q")).SendKeys("cheese" + Keys.Enter);
+            IWebElement firstResult = wait.Until(ExpectedConditions.ElementExists(By.CssSelector("h3>a")));
             Console.WriteLine(firstResult.Text);
-        }
-
-        [TestCleanup]
-        public void TearDown()
-        {
-            driver.Quit();
         }
     }
 }</code>


### PR DESCRIPTION
Align with Java version.

But I'm not sure whether c#'s `ExpectedConditions.ElementExists` is the same as Java's `ExpectedConditions.presenceOfElementLocated`.

```c#
using System;
using OpenQA.Selenium;
using OpenQA.Selenium.Firefox;
using OpenQA.Selenium.Support.UI;
using SeleniumExtras.WaitHelpers;

class HelloSelenium
{
    static void Main()
    {
        using (IWebDriver driver = new FirefoxDriver())
        {
            WebDriverWait wait = new WebDriverWait(driver, TimeSpan.FromSeconds(10));
            driver.Navigate().GoToUrl("https://www.google.com/ncr");
            driver.FindElement(By.Name("q")).SendKeys("cheese" + Keys.Enter);
            IWebElement firstResult = wait.Until(ExpectedConditions.ElementExists(By.CssSelector("h3>a")));
            Console.WriteLine(firstResult.Text);
        }
    }
}
```