### PR TITLE
Duplicate translation in two languages on the quick tour page.

### DIFF
--- a/docs_source_files/content/getting_started/quick.es.md
+++ b/docs_source_files/content/getting_started/quick.es.md
@@ -31,9 +31,5 @@ Poco después del desarrollo de las pruebas de WebDriver, es posible que deba ej
 
 ## HTML Runner
 
-This tool allows you to run Test Suites from the command
-line. Test Suites are HTML exports from Selenium IDE or compatible
-tools. _[HTML Runner]({{< ref "/getting_started/html-runner.es.md" >}})_
-
 Esta herramienta le permite ejecutar Test Suites desde la línea de comandos. Las suites de prueba son exportaciones HTML desde Selenium IDE o herramientas compatibles. _[HTML Runner]({{< ref "/getting_started/html-runner.es.md">}})_
 


### PR DESCRIPTION
On the quick tour page there was a duplicate text. The same in English and Spanish. The line that did not correspond to the translation has been removed.

CLA signed